### PR TITLE
added flag to identify if the filter state was changed

### DIFF
--- a/tasks/VelocityProvider.hpp
+++ b/tasks/VelocityProvider.hpp
@@ -38,6 +38,7 @@ namespace uwv_kalman_filters {
         unsigned streams_with_alignment_failures;
 	unsigned streams_with_critical_alignment_failures;
         Eigen::Vector3d current_angular_velocity;
+        bool filter_state_changed;
         States last_state;
         States new_state;
 


### PR DESCRIPTION
avoids sending out samples with initial (zero) or repeating timestamps