### PR TITLE
make CRITICAL_ALIGNMENT_FAILURE an exception

### DIFF
--- a/tasks/VelocityProvider.cpp
+++ b/tasks/VelocityProvider.cpp
@@ -239,7 +239,7 @@ void VelocityProvider::updateHook()
     if(streams_with_alignment_failures > 0)
         new_state = TRANSFORMATION_ALIGNMENT_FAILURES;
     if(streams_with_critical_alignment_failures > 0)
-	error(CRITICAL_ALIGNMENT_FAILURE);
+        exception(CRITICAL_ALIGNMENT_FAILURE);
 
     // write estimated body state
     VelocityUKF::State current_state;

--- a/uwv_kalman_filters.orogen
+++ b/uwv_kalman_filters.orogen
@@ -78,7 +78,7 @@ task_context "VelocityProvider" do
     #******** Task States *********
     #******************************
     runtime_states :MISSING_TRANSFORMATION, :TRANSFORMATION_ALIGNMENT_FAILURES
-    error_states :CRITICAL_ALIGNMENT_FAILURE
+    exception_states :CRITICAL_ALIGNMENT_FAILURE
 
     periodic 0.01
 end


### PR DESCRIPTION
The component is currently completely non-functional when in this
state, so let's make the component report that it's not functional